### PR TITLE
layout:DesktopNav 마크업,css완료, / Link를 통한 페이지이동

### DIFF
--- a/src/components/DesktopNav/DesktopNav.scss
+++ b/src/components/DesktopNav/DesktopNav.scss
@@ -1,0 +1,58 @@
+nav {
+  width: 100vw;
+  height: 120px;
+
+  .navWrapper {
+    width: 100%;
+    background-color: #ffffff;
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    left: 0;
+
+    .navTop {
+      width: 100%;
+      height: 50px;
+      position: relative;
+
+      .logoLeaf {
+        width: 40px;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+
+      .iconUser {
+        width: 30px;
+        position: absolute;
+        top: 50%;
+        right: 20px;
+      }
+    }
+
+    .navBottom {
+      width: 100%;
+      height: 70px;
+
+      .navTitle {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        width: 400px;
+        height: 100%;
+        padding: 20px;
+        font-weight: 500;
+
+        a {
+          color: #000000;
+        }
+
+        a:hover {
+          color: var(--mainColor--green);
+        }
+      }
+    }
+  }
+}

--- a/src/components/DesktopNav/DesktopNav.tsx
+++ b/src/components/DesktopNav/DesktopNav.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import userIcon from "../../assets/svg/icon-user.svg";
+import "../DesktopNav/DesktopNav.scss";
+import { Link } from "react-router-dom";
+
+export default function DesktopNav() {
+  return (
+    <>
+      <nav>
+        <div className="navWrapper">
+          <div className="navTop">
+            <Link to="/">
+              <img src="/favicon.ico" alt="go to home" className="logoLeaf" />
+            </Link>
+            <img src={userIcon} alt="user page" className="iconUser" />
+          </div>
+          <div className="navBottom">
+            <div className="navTitle">
+              <Link to={"/chat"}>그리니즈에게 상담하기</Link>
+              <Link to={"/introduce"}>그리니즈 소개</Link>
+              <Link to={"/sustainability"}>지속가능성</Link>
+            </div>
+          </div>
+        </div>
+      </nav>
+    </>
+  );
+}


### PR DESCRIPTION
<img width="1720" alt="image" src="https://github.com/namu2267/Greeneeds/assets/104307414/1c534fbf-fd19-49bb-ad19-d7769d852da7">
<br/>
<br/>
<br/>

# 내비게이션 바의 layout완성
- markup과 css
- Link태그를 통한 페이지 이동

## 1. markup
>`nav`태그 사용

> `<Link>`를 통해 페이지 이동
1️⃣ 가운데 '로고'를 누르면 main페이지(/)로 이동
2️⃣ '그리니즈에게 상담하기'를 누르면 chat페이지(/chat)로 이동
3️⃣ '그리니즈 소개'를 누르면 introduce페이지(/introduce)로 이동
4️⃣ '지속가능성'을 누르면 sustainability페이지(/sustainability)로 이동


## 2. css
> `position: fixed;`를 이용한 내비게이션바 고정
