### PR TITLE
Layout/desktop nav의 z-index 높임

### DIFF
--- a/src/components/DesktopNav/DesktopNav.scss
+++ b/src/components/DesktopNav/DesktopNav.scss
@@ -10,6 +10,7 @@ nav {
     position: fixed;
     top: 0;
     left: 0;
+    z-index: 2000;
 
     .navTop {
       width: 100%;

--- a/src/pages/sustainability/sustainabilityPage.tsx
+++ b/src/pages/sustainability/sustainabilityPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function ReasonPage() {
+export default function SustainabilityPage() {
   return (
     <div>
       탄소중립을 지켜야하는 이유 페이지 / 친환경 활동 소개 및 중요성 강조


### PR DESCRIPTION
# desktop nav의 z-index 부여 
- nav라서 2000이라는 높은 값 부여

## 문제 원인
### swiper 라이브러리에 자동으로 z-index:1이 부여됨
### ➡️ 해당 부분(캐러셀)을 지날때마다 nav가 아래로 깔리는 현상 발생

https://github.com/namu2267/Greeneeds/assets/104307414/7b217182-4e46-4275-bc17-f40319007960




## 해결:  navWrapper의 z-index 부여 (2000)
